### PR TITLE
Add `model_options` to settings.json

### DIFF
--- a/fm_agent/fm_agent.py
+++ b/fm_agent/fm_agent.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 mbed SDK
-Copyright (c) 2011-2018 ARM Limited
+Copyright (c) 2011-2021 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -70,9 +70,11 @@ class FastmodelAgent():
             self.logger.prn_err("NO model_binary available for '%s'"% self.fastmodel_name)
             self.__guide()
             raise SimulatorError("fastmodel '%s' not available" % (self.fastmodel_name))
-            
+
+        self.model_options = self.configuration.get_model_options(self.fastmodel_name)
+
         config_dict = self.configuration.get_configs(self.fastmodel_name)
-        
+
         if config_dict and self.config_name in config_dict:
             config_file = config_dict[self.config_name]
             self.model_config_file = os.path.join( os.path.dirname(__file__) ,"configs" , config_file )
@@ -114,7 +116,7 @@ class FastmodelAgent():
         """ launch given fastmodel with configs """
         if check_import():
             import iris.debug
-            proc, IRIS_port, outs = launch_FVP_IRIS(self.model_binary, self.model_config_file)
+            proc, IRIS_port, outs = launch_FVP_IRIS(self.model_binary, self.model_config_file, self.model_options)
             print(outs)
             self.model = iris.debug.NetworkModel('localhost',IRIS_port)
             # check which host socket port is used for terminal0

--- a/fm_agent/fm_config.py
+++ b/fm_agent/fm_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 mbed SDK
-Copyright (c) 2011-2018 ARM Limited
+Copyright (c) 2011-2021 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -66,6 +66,19 @@ class FastmodelConfig():
             return None
   
         return self.json_configs[model_name]["model_binary"]
+
+    def get_model_options(self,model_name):
+        """ get the model binary options from the config file
+            @return a list of model options
+            @return an empty list if not found
+        """
+        if model_name not in self.json_configs:
+            return []
+
+        if "model_options" not in self.json_configs[model_name]:
+            return []
+
+        return self.json_configs[model_name]["model_options"]
 
     def get_model_terminal_comp(self,model_name):
         """ get the model terminal compoment name from the config file

--- a/fm_agent/settings.json
+++ b/fm_agent/settings.json
@@ -8,6 +8,9 @@
     },
     "FVP_CS300_U55": {
         "model_binary": "/opt/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4//FVP_Corstone_SSE-300_Ethos-U55",
+        "model_options": [
+            "--quantum=10"
+        ],
         "terminal_component": "component.FVP_MPS3_Corstone_SSE_300.mps3_board.telnetterminal0",
         "configs": {
             "MPS3": "MPS3.conf"

--- a/fm_agent/utils.py
+++ b/fm_agent/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 mbed SDK
-Copyright (c) 2011-2018 ARM Limited
+Copyright (c) 2011-2021 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -133,9 +133,10 @@ def enqueue_output(out, queue):
         queue.put(line)
     out.close()
 
-def launch_FVP_IRIS(model_exec, config_file=''):
+def launch_FVP_IRIS(model_exec, config_file='', model_options=[]):
     """Launch FVP with IRIS Server listening"""
     cmd_line = [model_exec, '-I', '-p']
+    cmd_line.extend(model_options)
     if config_file:
         cmd_line.extend(['-f' , config_file])
     fm_proc = Popen(cmd_line,stdout=PIPE,stderr=STDOUT, close_fds=ON_POSIX)


### PR DESCRIPTION
This patch extends the configuration capabilities of the fm_agent.

Until now, loading the model parameters from the configuration file was
sufficient, but not all params can be set this way. The `--quantum=N` is
one example. We need to decrease this value so the timing of the model
better matches real hardware.

Signed-off-by: Filip Jagodzinski <filip.jagodzinski@arm.com>