### PR TITLE
Interpret strings like '{{foo}}' as environment variable references in paths found in settings.json (+ bug fixes)

### DIFF
--- a/fm_agent/fm_agent.py
+++ b/fm_agent/fm_agent.py
@@ -26,12 +26,12 @@ from .fm_config import FastmodelConfig
 class FastmodelAgent():
     def __init__(self, model_name=None, model_config=None, logger=None):
         """ initialize FastmodelAgent
-            @param all are optional, if none of the argument give, will just query for information 
+            @param all are optional, if none of the argument give, will just query for information
             @param if want to launch and connect to fast model, model_name and model_config are necessary
             @param model_name is the name to the fast model
             @param model_config is the config file to the fast model
         """
-        
+
         self.fastmodel_name = model_name
         self.config_name    = model_config
 
@@ -80,11 +80,11 @@ class FastmodelAgent():
             self.model_config_file = os.path.join( os.path.dirname(__file__) ,"configs" , config_file )
 
         elif os.path.exists(os.path.join( os.getcwd(), self.config_name )):
-            self.model_config_file = os.path.join( os.getcwd() , config_name )
+            self.model_config_file = os.path.join( os.getcwd() , self.config_name )
         else:
             self.__guide()
             raise SimulatorError("No config %s avaliable for fastmodel %s" % (self.config_name,self.fastmodel_name))
-        
+
         self.model_terminal = self.configuration.get_model_terminal_comp(self.fastmodel_name)
 
         if not self.model_terminal:
@@ -107,11 +107,11 @@ class FastmodelAgent():
     def __guide(self):
         """ print out information mebdls, help user to spot where possible went wrong"""
         self.logger.prn_inf("Use 'mbedfm' to list all the available Fast Models")
-    
+
     def is_simulator_alive(self):
         """return if the terminal socket is connected"""
         return bool(self.model)
-        
+
     def start_simulator(self):
         """ launch given fastmodel with configs """
         if check_import():
@@ -186,10 +186,10 @@ class FastmodelAgent():
             return False
 
     def read(self):
-    
+
         if not self.__socketConnected():
             return None
-        
+
         data = bytearray()
         read_stop = False
 
@@ -260,7 +260,7 @@ class FastmodelAgent():
 
     def __CodeCoverage(self):
         """ runs code coverage dump gcda file """
-        
+
         self.model.stop()
         cpu = self.model.get_cpus()[0]
 
@@ -318,14 +318,14 @@ class FastmodelAgent():
             else:
                 stopped_loc = cpu.read_register('Core.R15')
                 break
-            
+
 
         if stopped_loc == bkpt_exit.address:
             self.logger.prn_inf("Coverage dump program run to the end.")
         else:
             self.logger.prn_wrn("Coverage dump ended somewhere else!!")
         lcov_collect(os.path.basename(self.image))
-        
+
     def shutdown_simulator(self):
         """ shutdown fastmodel if any """
         if self.is_simulator_alive():
@@ -338,7 +338,7 @@ class FastmodelAgent():
             time.sleep(1)
         else:
             self.logger.prn_inf("Model already shutdown")
-            
+
     def list_avaliable_models(self):
         """ return a dictionary of models and configs """
         return self.configuration.get_all_configs()
@@ -346,7 +346,7 @@ class FastmodelAgent():
     def list_model_binary(self, model_name):
         """ return model binary full path of give model_name """
         return self.configuration.get_model_binary(model_name)
-        
+
     def check_config_exist(self,filename):
         """ return the presents of give config name
         """

--- a/fm_agent/fm_config.py
+++ b/fm_agent/fm_config.py
@@ -18,21 +18,22 @@ limitations under the License.
 
 import json
 import os.path
-from .utils import SimulatorError
+import os
+from .utils import SimulatorError, getenv_replace
 
 class FastmodelConfig():
-    
+
     # default settings file
     SETTINGS_FILE = "settings.json"
-            
+
     def __init__(self):
         """ initialization of FastmodelConfig """
-        
+
         settings_json_file = os.path.join(os.path.dirname(__file__), self.SETTINGS_FILE)
 
-        with open(settings_json_file,"r") as config_json:    
+        with open(settings_json_file,"r") as config_json:
             self.json_configs = json.load(config_json)
-        
+
     def get_all_configs (self):
         """ search every config for all the models in SETTINGS_FILE
             @return a dictionary for configs and models combination
@@ -46,11 +47,11 @@ class FastmodelConfig():
 
     def get_IRIS_path(self):
         """ get the IRIS path from the config file
-            @return IRIS path if setting exist 
+            @return IRIS path if setting exist
             @return None if not exist
         """
         if "IRIS_path" in self.json_configs["COMMON"]:
-            return self.json_configs["COMMON"]["IRIS_path"]
+            return getenv_replace(self.json_configs["COMMON"]["IRIS_path"])
         else:
             return None
 
@@ -64,8 +65,8 @@ class FastmodelConfig():
 
         if "model_binary" not in self.json_configs[model_name]:
             return None
-  
-        return self.json_configs[model_name]["model_binary"]
+
+        return getenv_replace(self.json_configs[model_name]["model_binary"])
 
     def get_model_options(self,model_name):
         """ get the model binary options from the config file
@@ -90,11 +91,11 @@ class FastmodelConfig():
 
         if "terminal_component" not in self.json_configs[model_name]:
             return None
-  
+
         return self.json_configs[model_name]["terminal_component"]
 
     def get_configs (self,model_name):
-        """ Search for configs with given model 
+        """ Search for configs with given model
             @return a dictionary of config_name:config_file for give model_name
             @return None if no config found
         """
@@ -110,4 +111,5 @@ class FastmodelConfig():
             return dict(global_configs,**addtion_configs)
         else:
             global_configs  = self.json_configs["COMMON"]["configs"].copy()
-            return global_configs        
+            return global_configs
+

--- a/fm_agent/utils.py
+++ b/fm_agent/utils.py
@@ -151,3 +151,8 @@ def launch_FVP_IRIS(model_exec, config_file='', model_options=[]):
             stdout = stdout + line + "\n"
 
     return (fm_proc, port, stdout)
+
+def getenv_replace(s):
+    """Replace substrings enclosed by {{ and }} with values from the environment so that e.g. '{{USER}}' becomes 'root'.
+    """
+    return s.replace('{{', '{').replace('}}', '}').format(**os.environ)

--- a/fm_agent/utils.py
+++ b/fm_agent/utils.py
@@ -20,6 +20,7 @@ import os
 import sys
 import logging
 from functools import partial
+import subprocess
 from subprocess import Popen, PIPE, STDOUT
 from threading  import Thread
 from queue import Queue, Empty
@@ -51,18 +52,8 @@ class FMLogger(object):
         self.prn_inf = partial(__prn_log, self, 'INF')
         self.prn_txt = partial(__prn_log, self, 'TXT')
         self.prn_txd = partial(__prn_log, self, 'TXD')
-        self.prn_rxd = partial(__prn_log, self, 'RXD')    
+        self.prn_rxd = partial(__prn_log, self, 'RXD')
 
-def get_IRIS_path(self):
-    """ get the IRIS path from the config file
-        @return IRIS path if setting exist 
-        @return None if not exist
-    """
-    if "IRIS_path" in self.json_configs["COMMON"]:
-        return self.json_configs["COMMON"]["IRIS_path"]
-    else:
-        return None
-        
 def check_import():
     """ try PyIRIS API iris.debug can be imported """
     warning_msgs = []
@@ -116,11 +107,11 @@ def ByteToInt( byteList ):
 
 def HexToInt( hex ):
     return int(hex,16)
-    
+
 def lcov_collect(filename):
     """this function reads images symbol to a global variable"""
     subprocess.call('lcov -c -d . --no-external -o BUILD/{}.info'.format(filename), shell=True)
-        
+
 def remove_gcda(rootdir="."):
     """this function removes gcda files"""
     for root, dirs, files in os.walk(rootdir):
@@ -149,7 +140,7 @@ def launch_FVP_IRIS(model_exec, config_file='', model_options=[]):
     stdout=''
     port = 0
     end = False
-    
+
     while not end:
         try: line = out_q.get(timeout=1).decode().strip()
         except Empty:
@@ -158,5 +149,5 @@ def launch_FVP_IRIS(model_exec, config_file='', model_options=[]):
             if line.startswith("Iris server started listening to port"):
                 port = int(line[-5:])
             stdout = stdout + line + "\n"
-        
+
     return (fm_proc, port, stdout)


### PR DESCRIPTION
Hi,

I found while using `fm_agent` that `settings.json` has strings with these `{{sequences}}` which look like they could/should be replaced by environment variables. These are the changes I made to my local copy of `fm_agent` to get it to work.