### PR TITLE
fm_agent/configs: TAP Interface enabled configs for MPS2/MPS3

### DIFF
--- a/fm_agent/configs/MPS2-tap-network.conf
+++ b/fm_agent/configs/MPS2-tap-network.conf
@@ -1,0 +1,25 @@
+## Turn off terminal1 and terminal2, keep terminal0 open
+fvp_mps2.telnetterminal1.quiet=1
+fvp_mps2.telnetterminal2.quiet=1
+
+## Control the output format of the telnet terminal
+fvp_mps2.telnetterminal0.mode=raw
+
+
+## Suppress the telnet/xterm to be launched, so that model agent can talk to the port  
+fvp_mps2.telnetterminal0.start_telnet=0
+
+
+## logging the UART output to a file
+# fvp_mps2.UART0.out_file=out_file.txt
+
+## turn the rate limite off
+fvp_mps2.mps2_visualisation.rate_limit-enable=0
+
+## Enable Ethernet Port
+## This configuration uses TAP Networking and the FVP expects the interface "ARMfmuser"
+## to be available and configured properly (bridged to an externl network).
+## You can setup FVP TAP Networking by following the documentation mentioned
+## here: https://developer.arm.com/documentation/100964/1113/Introduction/Network-set-up/TAP-TUN-networking
+fvp_mps2.hostbridge.interfaceName=ARMfmuser
+fvp_mps2.smsc_91c111.enabled=1

--- a/fm_agent/configs/MPS3-tap-network.conf
+++ b/fm_agent/configs/MPS3-tap-network.conf
@@ -1,0 +1,25 @@
+## Turn off terminal1 terminal2 and termimal5, keep terminal0 open
+mps3_board.telnetterminal1.quiet=1
+mps3_board.telnetterminal2.quiet=1
+mps3_board.telnetterminal5.quiet=1
+
+## Control the output format of the telnet terminal
+mps3_board.telnetterminal0.mode=raw
+## Suppress the telnet/xterm to be launched, so that model agent can talk to the port  
+mps3_board.telnetterminal0.start_telnet=0
+
+
+## Turn the rate limite off, make FVP runs as fast as possiable
+mps3_board.visualisation.rate_limit-enable=0
+
+
+## Enable Ethernet Port
+## This configuration uses TAP Networking and the FVP expects the interface "ARMfmuser"
+## to be available and configured properly (bridged to an externl network).
+## You can setup FVP TAP Networking by following the documentation mentioned
+## here: https://developer.arm.com/documentation/100964/1113/Introduction/Network-set-up/TAP-TUN-networking
+mps3_board.smsc_91c111.enabled=1
+mps3_board.hostbridge.interfaceName=ARMfmuser
+
+## Turn off GUI windows
+mps3_board.visualisation.disable-visualisation=1


### PR DESCRIPTION
This commit adds new configs for MPS2/MPS3 which are exactly
the same as the original configs except for the fact that they
use TAP Networking instead of User Networking. This feature
will help enable emac ctp testing (which can’t be tested with
user networking).

Signed-off-by: Bilal Wasim <muhammadbilal.wasim@arm.com>