### PR TITLE
Store subprocess in fm_agent and ensure the process is killed when FastmodelAgent is destroyed

### DIFF
--- a/fm_agent/fm_agent.py
+++ b/fm_agent/fm_agent.py
@@ -37,6 +37,7 @@ class FastmodelAgent():
         self.fastmodel_name = model_name
         self.config_name    = model_config
         self.enable_gdbserver = enable_gdbserver
+        self.subprocess = None
 
         #If logging not provided, use default log
         if logger:
@@ -132,7 +133,7 @@ class FastmodelAgent():
         """ launch given fastmodel with configs """
         if check_import():
             import iris.debug
-            proc, IRIS_port, outs = launch_FVP_IRIS(self.model_binary, self.model_config_file, self.model_options)
+            self.subprocess, IRIS_port, outs = launch_FVP_IRIS(self.model_binary, self.model_config_file, self.model_options)
             if stream:
                 print(outs, file=stream)
             self.model = iris.debug.NetworkModel('localhost',IRIS_port)
@@ -183,7 +184,7 @@ class FastmodelAgent():
             time.sleep(1)
             import iris.debug
 
-            proc, IRIS_port, outs = launch_FVP_IRIS(self.model_binary, self.model_config_file)
+            self.subprocess, IRIS_port, outs = launch_FVP_IRIS(self.model_binary, self.model_config_file)
             if IRIS_port==0:
                 print(outs)
                 return False

--- a/fm_agent/fm_agent.py
+++ b/fm_agent/fm_agent.py
@@ -18,6 +18,7 @@ limitations under the License.
 
 import sys
 import os
+from subprocess import Popen
 import time
 import socket
 from .utils import *
@@ -54,6 +55,10 @@ class FastmodelAgent():
             self.setup_simulator(model_name,model_config)
         else:
             pass
+
+    def __del__(self):
+        if isinstance(self.subprocess, Popen):
+            self.subprocess.kill()
 
     def setup_simulator(self, model_name, model_config):
         """ setup the simulator, this is crucial before you can start a simulator.


### PR DESCRIPTION
Instead of being discarded, the `Popen` object can be used to interact with the subprocess and ensure that it is terminated at program end.

Use case: The FVP subprocess does not always terminate when the master process ends.