### PR TITLE
Set IRIS path in config

### DIFF
--- a/fm_agent/fm_agent.py
+++ b/fm_agent/fm_agent.py
@@ -192,7 +192,7 @@ class FastmodelAgent():
 
     def start_simulator(self, stream=sys.stdout):
         """ launch given fastmodel with configs """
-        if check_import():
+        if check_import(self.fastmodel_name):
             import iris.debug
             self.subprocess, IRIS_port, outs = launch_FVP_IRIS(self.model_binary, self.model_config_file, self.model_options)
             if stream:

--- a/fm_agent/fm_agent.py
+++ b/fm_agent/fm_agent.py
@@ -139,7 +139,11 @@ class FastmodelAgent():
         self.model_options = self.configuration.get_model_options(self.fastmodel_name)
 
         self.telnet_port = self._telnet_port_allocator.allocate()
-        self.model_options += ['-C', f'mps3_board.telnetterminal0.start_port={self.telnet_port.value}']
+
+        if self.config_name == "MPS2":
+            self.model_options += ['-C', f'fvp_mps2.telnetterminal0.start_port={self.telnet_port.value}']
+        elif self.config_name == "MPS3":
+            self.model_options += ['-C', f'mps3_board.telnetterminal0.start_port={self.telnet_port.value}']
 
         if self.enable_gdbserver:
             self.gdb_port = self._gdb_port_allocator.allocate()

--- a/fm_agent/fm_config.py
+++ b/fm_agent/fm_config.py
@@ -45,15 +45,19 @@ class FastmodelConfig():
 
         return all_config_dict
 
-    def get_IRIS_path(self):
+    def get_IRIS_path(self, model_name):
         """ get the IRIS path from the config file
             @return IRIS path if setting exist
             @return None if not exist
         """
+        if model_name != "":
+            return getenv_replace(self.json_configs[model_name]["IRIS_path"])
+
         if "IRIS_path" in self.json_configs["COMMON"]:
             return getenv_replace(self.json_configs["COMMON"]["IRIS_path"])
         else:
             return None
+
 
     def get_model_binary(self,model_name):
         """ get the model binary path and name from the config file

--- a/fm_agent/utils.py
+++ b/fm_agent/utils.py
@@ -54,13 +54,13 @@ class FMLogger(object):
         self.prn_txd = partial(__prn_log, self, 'TXD')
         self.prn_rxd = partial(__prn_log, self, 'RXD')
 
-def check_import():
+def check_import(model_name=""):
     """ try PyIRIS API iris.debug can be imported """
     warning_msgs = []
     from .fm_config import FastmodelConfig
     config = FastmodelConfig()
 
-    fm_IRIS_path = config.get_IRIS_path()
+    fm_IRIS_path = config.get_IRIS_path(model_name)
     if fm_IRIS_path:
         if os.path.exists(fm_IRIS_path):
             sys.path.append(fm_IRIS_path)


### PR DESCRIPTION
To combine settings for MPS2, MPS3 FVP configurations IRIS path and port must be set as configurable.